### PR TITLE
Fix the github links in the documentation impacted by the repo transfer from yidongnan/grpc-spring-boot-starter to grpc-ecosystem/grpc-spring.

### DIFF
--- a/docs/assets/images/client-project-setup.dot
+++ b/docs/assets/images/client-project-setup.dot
@@ -39,7 +39,7 @@ digraph serversetup {
 		fillColor="white";
 		fontcolor="gray50";
 
-		serviceimpl [label="Service implementations", color="gray50", fontcolor="gray50",fillcolor="white",width="3", URL="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49", target="_blank"];
+		serviceimpl [label="Service implementations", color="gray50", fontcolor="gray50",fillcolor="white",width="3", URL="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49", target="_blank"];
 
 		servicemodel -> serviceimpl [style=dashed, color="gray50", dir=back];
 
@@ -49,7 +49,7 @@ digraph serversetup {
 
 		label="Client-Projects";
 
-		clientfield [label="Client/Stub usage", width="3", URL="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69", target="_blank"];
+		clientfield [label="Client/Stub usage", width="3", URL="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69", target="_blank"];
 
 		servicemodel:se -> clientfield[style=dashed, dir=back];
 		servicemodel:se -> clientfield[style=dashed, dir=back, weight=0];

--- a/docs/assets/images/client-project-setup.svg
+++ b/docs/assets/images/client-project-setup.svg
@@ -101,7 +101,7 @@
 </g>
 <!-- serviceimpl -->
 <g id="node7" class="node"><title>serviceimpl</title>
-<g id="a_node7"><a xlink:href="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49" xlink:title="Service implementations" target="_blank">
+<g id="a_node7"><a xlink:href="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49" xlink:title="Service implementations" target="_blank">
 <ellipse fill="none" stroke="#7f7f7f" cx="679.185" cy="-122" rx="108" ry="18"/>
 <text text-anchor="middle" x="679.185" y="-118.3" font-family="Times New Roman,serif" font-size="14.00" fill="#7f7f7f">Service implementations</text>
 </a>
@@ -114,7 +114,7 @@
 </g>
 <!-- clientfield -->
 <g id="node8" class="node"><title>clientfield</title>
-<g id="a_node8"><a xlink:href="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69" xlink:title="Client/Stub usage" target="_blank">
+<g id="a_node8"><a xlink:href="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69" xlink:title="Client/Stub usage" target="_blank">
 <ellipse fill="none" stroke="black" cx="679.185" cy="-39" rx="108" ry="18"/>
 <text text-anchor="middle" x="679.185" y="-35.3" font-family="Times New Roman,serif" font-size="14.00">Client/Stub usage</text>
 </a>

--- a/docs/assets/images/server-project-setup.dot
+++ b/docs/assets/images/server-project-setup.dot
@@ -36,7 +36,7 @@ digraph serversetup {
 
 		label="Server-Project"
 
-		serviceimpl [label="Service implementations", width="3", URL="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49", target="_blank"];
+		serviceimpl [label="Service implementations", width="3", URL="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49", target="_blank"];
 
 		servicemodel -> serviceimpl [style=dashed, dir=back];
 
@@ -49,7 +49,7 @@ digraph serversetup {
 		fillColor="white";
 		fontcolor="gray50";
 
-		clientfield [label="Client/Stub usage", width="3", color="gray50", fontcolor="gray50",fillcolor="white", URL="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69", target="_blank"];
+		clientfield [label="Client/Stub usage", width="3", color="gray50", fontcolor="gray50",fillcolor="white", URL="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69", target="_blank"];
 
 		servicemodel:se -> clientfield[style=dashed, dir=back, color="gray50"];
 		servicemodel:se -> clientfield[style=dashed, dir=back, color="gray50", weight=0];

--- a/docs/assets/images/server-project-setup.svg
+++ b/docs/assets/images/server-project-setup.svg
@@ -101,7 +101,7 @@
 </g>
 <!-- serviceimpl -->
 <g id="node7" class="node"><title>serviceimpl</title>
-<g id="a_node7"><a xlink:href="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49" xlink:title="Service implementations" target="_blank">
+<g id="a_node7"><a xlink:href="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java#L49" xlink:title="Service implementations" target="_blank">
 <ellipse fill="none" stroke="black" cx="679.185" cy="-122" rx="108" ry="18"/>
 <text text-anchor="middle" x="679.185" y="-118.3" font-family="Times New Roman,serif" font-size="14.00">Service implementations</text>
 </a>
@@ -114,7 +114,7 @@
 </g>
 <!-- clientfield -->
 <g id="node8" class="node"><title>clientfield</title>
-<g id="a_node8"><a xlink:href="https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69" xlink:title="Client/Stub usage" target="_blank">
+<g id="a_node8"><a xlink:href="https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java#L69" xlink:title="Client/Stub usage" target="_blank">
 <ellipse fill="none" stroke="#7f7f7f" cx="679.185" cy="-39" rx="108" ry="18"/>
 <text text-anchor="middle" x="679.185" y="-35.3" font-family="Times New Roman,serif" font-size="14.00" fill="#7f7f7f">Client/Stub usage</text>
 </a>

--- a/docs/en/client/configuration.md
+++ b/docs/en/client/configuration.md
@@ -36,7 +36,7 @@ You can find all build-in configuration properties here:
 - [`GrpcServerProperties.Security`](https://static.javadoc.io/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelProperties.Security.html)
 
 If you prefer to read the sources instead, you can do so
-[here](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java#L58).
+[here](https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java#L58).
 
 The properties for the channels are all prefixed with `grpc.client.__name__.` and `grpc.client.__name__.security.`
 respectively. The channel name is taken from the `@GrpcClient("__name__")` annotation.
@@ -322,7 +322,7 @@ using a custom `NameResolverProvider`.
 > **Note:** This can only be used to decide this on an application level and not on a per request level.
 
 This library provides some `NameResolverProvider`s itself so you can use them as a
-[reference](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver).
+[reference](https://github.com/grpc-ecosystem/grpc-spring/tree/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver).
 
 You can register your `NameResolverProvider` by adding it to `META-INF/services/io.grpc.NameResolverProvider` for Java's
 `ServiceLoader` or adding it your spring context. If you wish to use some spring beans inside your `NameResolver`, then

--- a/docs/en/contributions.md
+++ b/docs/en/contributions.md
@@ -4,9 +4,9 @@
 
 Contributions are always welcome.
 
-For more information refer to our [contribution guidelines](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/CONTRIBUTING.md).
+For more information refer to our [contribution guidelines](https://github.com/grpc-ecosystem/grpc-spring/blob/master/CONTRIBUTING.md).
 
-**Thanks to all our [contributors](https://github.com/yidongnan/grpc-spring-boot-starter/graphs/contributors)!**
+**Thanks to all our [contributors](https://github.com/grpc-ecosystem/grpc-spring/graphs/contributors)!**
 
 ----------
 

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -6,30 +6,30 @@ These projects work as is and could be used as templates for your own projects.
 We use them to verify that this library works in different environments, and we don't break anything unnoticed.
 
 > **Note:** If you have questions regarding these sample projects or would like an example for another use case,
-> feel free to open an [issue](https://github.com/yidongnan/grpc-spring-boot-starter/issues).
+> feel free to open an [issue](https://github.com/grpc-ecosystem/grpc-spring/issues).
 
 ## Local example
 
 The simplest setup of all, using a local server and one or more clients.
 
-- [Server](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/local-grpc-server)
-- [Client](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/local-grpc-client)
-- [Instructions](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#local-mode)
+- [Server](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/local-grpc-server)
+- [Client](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/local-grpc-client)
+- [Instructions](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#local-mode)
 
 ## Cloud example
 
 A setup for cloud environments using a eureka service discovery service.
 
-- [Eureka-Server](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-eureka-server)
-- [Server](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-grpc-server)
-- [Client](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-grpc-client)
-- [Instructions](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#cloud-mode)
+- [Eureka-Server](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-eureka-server)
+- [Server](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-grpc-server)
+- [Client](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-grpc-client)
+- [Instructions](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#cloud-mode)
 
 ## Basic Auth Example
 
 A setup that demonstrates the usage of spring-security with grpc.
 This setup uses basic auth for simplicity reasons, but other authentication mechanism can be used for this as well.
 
-- [Server](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/security-grpc-server)
-- [Client](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/security-grpc-client)
-- [Instructions](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#with-basic-auth-security)
+- [Server](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/security-grpc-server)
+- [Client](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/security-grpc-client)
+- [Instructions](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#with-basic-auth-security)

--- a/docs/en/server/configuration.md
+++ b/docs/en/server/configuration.md
@@ -35,7 +35,7 @@ You can find all build-in configuration properties here:
 - [`GrpcServerProperties.Security`](https://javadoc.io/page/net.devh/grpc-server-spring-boot-autoconfigure/latest/net/devh/boot/grpc/server/config/GrpcServerProperties.Security.html)
 
 If you prefer to read the sources instead, you can do so
-[here](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java#L50).
+[here](https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java#L50).
 
 The properties for the server are all prefixed with `grpc.server.` and `grpc.server.security.` respectively.
 

--- a/docs/en/server/testing.md
+++ b/docs/en/server/testing.md
@@ -34,7 +34,7 @@ We all know how important it is to test our application, so I will only refer yo
 
 - [Testing Spring](https://docs.spring.io/spring/docs/current/spring-framework-reference/testing.html)
 - [Testing with JUnit](https://junit.org/junit5/docs/current/user-guide/#writing-tests)
-- [grpc-spring-boot-starter's Tests](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/tests/src/test/java/net/devh/boot/grpc/test)
+- [grpc-spring-boot-starter's Tests](https://github.com/grpc-ecosystem/grpc-spring/tree/master/tests/src/test/java/net/devh/boot/grpc/test)
 
 Generally there are three ways to test your grpc service:
 

--- a/docs/en/versions.md
+++ b/docs/en/versions.md
@@ -35,7 +35,7 @@ If you need a patched version, please open an issue.
 
 This table shows the spring and gRPC version that this library ships.
 In most cases you can upgrade to newer versions, but especially gRPC changes its API more frequently.
-Please report any issues to our [repo](https://github.com/yidongnan/grpc-spring-boot-starter/issues).
+Please report any issues to our [repo](https://github.com/grpc-ecosystem/grpc-spring/issues).
 
 > **Note**
 >
@@ -106,7 +106,7 @@ If you upgrade any of the versions we strongly recommend doing so using a bom:
 
 Refer to the release notes for more information on the changes for each version:
 
-- [grpc-spring-boot-starter](https://github.com/yidongnan/grpc-spring-boot-starter/releases)
+- [grpc-spring-boot-starter](https://github.com/grpc-ecosystem/grpc-spring/releases)
 - [spring-boot](https://github.com/spring-projects/spring-boot/releases)
 - [grpc-java](https://github.com/grpc/grpc-java/releases)
 

--- a/docs/zh-CN/client/configuration.md
+++ b/docs/zh-CN/client/configuration.md
@@ -33,7 +33,7 @@ grpc-spring-boot-starter 可以通过 Spring 的 `@ConfigurationProperties` 机�
 - [`GrpcChannelProperties`](https://javadoc.io/page/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelProperties.html)
 - [`GrpcServerProperties.Security`](https://static.javadoc.io/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelProperties.Security.html)
 
-如果你希望阅读源代码，你可以查阅 [这里](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java#L58)。
+如果你希望阅读源代码，你可以查阅 [这里](https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java#L58)。
 
 Channels 的属性都是以 `grpc.client.__name__.` 或 `grpc.client.__name__.security.` 为前缀。 Channel 的名称从 `@GrpcClient("__name__")` 注解中获取。 如果您想要配置一些其他的选项，如为所有服务端设置可信证书，并可以使用 `GLOBAL` 作为名称。 指定 Channel 的配置项优先于 `GLOBAL` 的配置项
 
@@ -268,7 +268,7 @@ public StubTransformer call() {
 
 > **注意：** 这只能用于在应用程序级别上，而不是应用在每个请求级别上。
 
-这个库内置提供了一些 `NameResolverProvider`，因此你可以直接使用 [它们](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver)。
+这个库内置提供了一些 `NameResolverProvider`，因此你可以直接使用 [它们](https://github.com/grpc-ecosystem/grpc-spring/tree/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver)。
 
 你也利用 Java 的 `ServiceLoader` ，在 `META-INF/services/io.grpc.NameResolverProvider` 文件中添加，或者通过在 spring context 中添加，以此注册自定义的 `NameResolverProvider`。 如果你想在你的 `NameResolver` 中使用一些 spring 的 bean， 那么你必须通过 spring 的 context 来定义它 (否则会使用使用 `static`)。
 

--- a/docs/zh-CN/contributions.md
+++ b/docs/zh-CN/contributions.md
@@ -4,9 +4,9 @@
 
 我们始终欢迎您对项目作出任何贡献。
 
-详情请参阅我们的[贡献准则](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/CONTRIBUTING.md)。
+详情请参阅我们的[贡献准则](https://github.com/grpc-ecosystem/grpc-spring/blob/master/CONTRIBUTING.md)。
 
-**感谢我们所有的[贡献者](https://github.com/yidongnan/grpc-spring-boot-starter/graphs/contributors)！**
+**感谢我们所有的[贡献者](https://github.com/grpc-ecosystem/grpc-spring/graphs/contributors)！**
 
 ----------
 

--- a/docs/zh-CN/examples.md
+++ b/docs/zh-CN/examples.md
@@ -4,29 +4,29 @@
 
 这些项目可以作为您自己的项目的模板。 我们使用它们来验证这个库在不同的环境中运行，我们不会在不受注意的情况下改变它的行为。
 
-> **注意:** 如果您对这些项目有疑问，或者想要其他的示例，随时可以提出一个 [issue](https://github.com/yidongnan/grpc-spring-boot-starter/issues)。
+> **注意:** 如果您对这些项目有疑问，或者想要其他的示例，随时可以提出一个 [issue](https://github.com/grpc-ecosystem/grpc-spring/issues)。
 
 ## 本地示例
 
 最简单的设置，使用本地服务端和一个或多个客户端
 
-- [服务端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/local-grpc-server)
-- [客户端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/local-grpc-client)
-- [说明](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#local-mode)
+- [服务端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/local-grpc-server)
+- [客户端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/local-grpc-client)
+- [说明](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#local-mode)
 
 ## Cloud 示例
 
 使用 eureka 服务发现的 Cloud 环境。
 
-- [Eureka 服务](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-eureka-server)
-- [服务端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-grpc-server)
-- [客户端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/cloud-grpc-client)
-- [说明](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#cloud-mode)
+- [Eureka 服务](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-eureka-server)
+- [服务端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-grpc-server)
+- [客户端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/cloud-grpc-client)
+- [说明](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#cloud-mode)
 
 ## 基础认证示例
 
 演示了 grpc 跟 spring security 的设置。 为了简单起见，此设置使用 Basic 身份验证，但也可以为其使用其他身份验证机制。
 
-- [服务端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/security-grpc-server)
-- [客户端](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples/security-grpc-client)
-- [说明](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/examples#with-basic-auth-security)
+- [服务端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/security-grpc-server)
+- [客户端](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples/security-grpc-client)
+- [说明](https://github.com/grpc-ecosystem/grpc-spring/tree/master/examples#with-basic-auth-security)

--- a/docs/zh-CN/server/configuration.md
+++ b/docs/zh-CN/server/configuration.md
@@ -32,7 +32,7 @@ grpc-spring-boot-starter 可以通过 Spring 的 `@ConfigurationProperties` 机�
 - [`GrpcServerProperties`](https://javadoc.io/page/net.devh/grpc-server-spring-boot-autoconfigure/latest/net/devh/boot/grpc/server/config/GrpcServerProperties.html)
 - [`GrpcServerProperties.Security`](https://javadoc.io/page/net.devh/grpc-server-spring-boot-autoconfigure/latest/net/devh/boot/grpc/server/config/GrpcServerProperties.Security.html)
 
-如果你希望阅读源代码，你可以查阅 [这里](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java#L50)。
+如果你希望阅读源代码，你可以查阅 [这里](https://github.com/grpc-ecosystem/grpc-spring/blob/master/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java#L50)。
 
 Channels 的属性都是以 `grpc.server..` 或 `grpc.client..security.` 为前缀。
 

--- a/docs/zh-CN/server/testing.md
+++ b/docs/zh-CN/server/testing.md
@@ -33,7 +33,7 @@
 
 - [Testing Spring](https://docs.spring.io/spring/docs/current/spring-framework-reference/testing.html)
 - [Testing with JUnit](https://junit.org/junit5/docs/current/user-guide/#writing-tests)
-- [grpc-spring-boot-starter's Tests](https://github.com/yidongnan/grpc-spring-boot-starter/tree/master/tests/src/test/java/net/devh/boot/grpc/test)
+- [grpc-spring-boot-starter's Tests](https://github.com/grpc-ecosystem/grpc-spring/tree/master/tests/src/test/java/net/devh/boot/grpc/test)
 
 通常有三种方法来测试您的 grpc 服务：
 

--- a/docs/zh-CN/versions.md
+++ b/docs/zh-CN/versions.md
@@ -28,7 +28,7 @@
 
 ## 版本列表
 
-下表显示了该项目和 spring boot 以及 gRPC 版本的关系。 在大多数情况下，你可以升级到较新的版本，但如果是 gRPC 改变了其 API。 请将任何问题报告给我们[仓库](https://github.com/yidongnan/grpc-spring-boot-starter/issues)。
+下表显示了该项目和 spring boot 以及 gRPC 版本的关系。 在大多数情况下，你可以升级到较新的版本，但如果是 gRPC 改变了其 API。 请将任何问题报告给我们[仓库](https://github.com/grpc-ecosystem/grpc-spring/issues)。
 
 > **注意**
 >
@@ -95,7 +95,7 @@
 
 有关每个版本的更改，请参考发行说明。
 
-- [grpc-spring-boot-starter](https://github.com/yidongnan/grpc-spring-boot-starter/releases)
+- [grpc-spring-boot-starter](https://github.com/grpc-ecosystem/grpc-spring/releases)
 - [spring-boot](https://github.com/spring-projects/spring-boot/releases)
 - [grpc-java](https://github.com/grpc/grpc-java/releases)
 


### PR DESCRIPTION
Fix the github links in the documentation impacted by the repo transfer from yidongnan/grpc-spring-boot-starter to grpc-ecosystem/grpc-spring.