### PR TITLE
feat: Adds structure for gRPC client metrics instrumentation

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.client.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/*
+ * The instruments used to record metrics on client.
+ */
+public class MetricsClientInstruments {
+
+    static final String CLIENT_ATTEMPT_STARTED = "grpc.client.attempt.started";
+
+    static MetricsMeters micrometerInstruments(MeterRegistry registry) {
+        MetricsMeters.Builder builder = MetricsMeters.newBuilder();
+
+        builder.setAttemptCounter(Counter.builder(CLIENT_ATTEMPT_STARTED)
+                .description("The total number of RPC attempts started, including those that have not completed.")
+                .baseUnit("attempt")
+                .withRegistry(registry));
+        return builder.build();
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
@@ -24,13 +24,20 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 public class MetricsClientInstruments {
 
-    static final String CLIENT_ATTEMPT_STARTED = "grpc.client.attempt.started";
+    /*
+     * This is a client side metric defined in gRFC <a
+     * href="https://github.com/grpc/proposal/blob/master/A66-otel-stats.md">A66</a>. Please note that this is the name
+     * used for instrumentation and can be changed by exporters in an unpredictable manner depending on the destination.
+     */
+    private static final String CLIENT_ATTEMPT_STARTED = "grpc.client.attempt.started";
 
-    static MetricsMeters micrometerInstruments(MeterRegistry registry) {
+    static MetricsMeters instruments(MeterRegistry registry) {
         MetricsMeters.Builder builder = MetricsMeters.newBuilder();
 
         builder.setAttemptCounter(Counter.builder(CLIENT_ATTEMPT_STARTED)
-                .description("The total number of RPC attempts started, including those that have not completed.")
+                .description(
+                        "The total number of RPC attempts started from the client side, including "
+                                + "those that have not completed.")
                 .baseUnit("attempt")
                 .withRegistry(registry));
         return builder.build();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
@@ -31,7 +31,7 @@ public class MetricsClientInstruments {
      */
     private static final String CLIENT_ATTEMPT_STARTED = "grpc.client.attempt.started";
 
-    static MetricsMeters instruments(MeterRegistry registry) {
+    static MetricsMeters newClientMetricsMeters(MeterRegistry registry) {
         MetricsMeters.Builder builder = MetricsMeters.newBuilder();
 
         builder.setAttemptCounter(Counter.builder(CLIENT_ATTEMPT_STARTED)

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInstruments.java
@@ -22,7 +22,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 /*
  * The instruments used to record metrics on client.
  */
-public class MetricsClientInstruments {
+public final class MetricsClientInstruments {
+
+    private MetricsClientInstruments() {}
 
     /*
      * This is a client side metric defined in gRFC <a

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
@@ -29,6 +29,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * A gRPC client interceptor that collects gRPC metrics.
+ *
+ * <b>Note:</b> This class uses experimental grpc-java-API features.
  */
 public class MetricsClientInterceptor implements ClientInterceptor {
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.client.metrics;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * A gRPC client interceptor that will collect gRPC metrics.
+ */
+public class MetricsClientInterceptor implements ClientInterceptor {
+
+    private final MeterRegistry registry;
+    private final MetricsMeters metricsMeters;
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given
+     * {@link io.micrometer.core.instrument.MeterRegistry}.
+     *
+     * @param meterRegistry The meter registry to use.
+     */
+    public MetricsClientInterceptor(MeterRegistry meterRegistry) {
+        this.registry = meterRegistry;
+        this.metricsMeters = MetricsClientInstruments.micrometerInstruments(this.registry);
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+        final MetricsClientStreamTracers.CallAttemptsTracerFactory tracerFactory =
+                new MetricsClientStreamTracers.CallAttemptsTracerFactory(method.getFullMethodName(),
+                        metricsMeters);
+
+        ClientCall<ReqT, RespT> call =
+                next.newCall(method, callOptions.withStreamTracerFactory(tracerFactory));
+
+        return new SimpleForwardingClientCall<ReqT, RespT>(call) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                delegate().start(
+                        new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                            @Override
+                            public void onClose(Status status, Metadata trailers) {
+                                super.onClose(status, trailers);
+                            }
+                        },
+                        headers);
+            }
+        };
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientInterceptor.java
@@ -28,22 +28,20 @@ import io.grpc.Status;
 import io.micrometer.core.instrument.MeterRegistry;
 
 /**
- * A gRPC client interceptor that will collect gRPC metrics.
+ * A gRPC client interceptor that collects gRPC metrics.
  */
 public class MetricsClientInterceptor implements ClientInterceptor {
 
-    private final MeterRegistry registry;
     private final MetricsMeters metricsMeters;
 
     /**
-     * Creates a new gRPC client interceptor that will collect metrics into the given
+     * Creates a new gRPC client interceptor that collects metrics into the given
      * {@link io.micrometer.core.instrument.MeterRegistry}.
      *
-     * @param meterRegistry The meter registry to use.
+     * @param registry The MeterRegistry to use.
      */
-    public MetricsClientInterceptor(MeterRegistry meterRegistry) {
-        this.registry = meterRegistry;
-        this.metricsMeters = MetricsClientInstruments.micrometerInstruments(this.registry);
+    public MetricsClientInterceptor(MeterRegistry registry) {
+        this.metricsMeters = MetricsClientInstruments.instruments(registry);
     }
 
     @Override
@@ -57,6 +55,7 @@ public class MetricsClientInterceptor implements ClientInterceptor {
         ClientCall<ReqT, RespT> call =
                 next.newCall(method, callOptions.withStreamTracerFactory(tracerFactory));
 
+        // TODO(dnvindhya): Add purpose of wrapping with SimpleForwardingClientCall
         return new SimpleForwardingClientCall<ReqT, RespT>(call) {
             @Override
             public void start(Listener<RespT> responseListener, Metadata headers) {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientStreamTracers.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientStreamTracers.java
@@ -34,9 +34,9 @@ import io.micrometer.core.instrument.Tags;
 public class MetricsClientStreamTracers {
 
     private static final class ClientTracer extends ClientStreamTracer {
-        final CallAttemptsTracerFactory attemptsState;
-        final StreamInfo info;
-        final String fullMethodName;
+        private final CallAttemptsTracerFactory attemptsState;
+        private final StreamInfo info;
+        private final String fullMethodName;
 
         ClientTracer(CallAttemptsTracerFactory attemptsState, StreamInfo info, String fullMethodName) {
             this.attemptsState = attemptsState;
@@ -58,7 +58,7 @@ public class MetricsClientStreamTracers {
 
             // Record here in case newClientStreamTracer() would never be called.
             this.metricsMeters.getAttemptCounter()
-                    .withTags((Tags.of("grpc.method", fullMethodName)))
+                    .withTags(Tags.of("grpc.method", fullMethodName))
                     .increment();
         }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientStreamTracers.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsClientStreamTracers.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.client.metrics;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
+import io.grpc.Metadata;
+import io.micrometer.core.instrument.Tags;
+
+/**
+ * Provides factories for {@link io.grpc.StreamTracer} that records metrics.
+ *
+ * <p>
+ * On the client-side, a factory is created for each call, and the factory creates a stream tracer for each attempt.
+ */
+public class MetricsClientStreamTracers {
+
+    private static final class ClientTracer extends ClientStreamTracer {
+        final CallAttemptsTracerFactory attemptsState;
+        final StreamInfo info;
+        final String fullMethodName;
+
+        ClientTracer(CallAttemptsTracerFactory attemptsState, StreamInfo info, String fullMethodName) {
+            this.attemptsState = attemptsState;
+            this.info = info;
+            this.fullMethodName = fullMethodName;
+        }
+
+    }
+
+    static final class CallAttemptsTracerFactory extends ClientStreamTracer.Factory {
+        private final String fullMethodName;
+        private final MetricsMeters metricsMeters;
+        private final AtomicLong attemptsPerCall = new AtomicLong();
+
+        CallAttemptsTracerFactory(String fullMethodName,
+                final MetricsMeters metricsMeters) {
+            this.fullMethodName = checkNotNull(fullMethodName, "fullMethodName");
+            this.metricsMeters = checkNotNull(metricsMeters, "metricsMeters");
+
+            // Record here in case newClientStreamTracer() would never be called.
+            this.metricsMeters.getAttemptCounter()
+                    .withTags((Tags.of("grpc.method", fullMethodName)))
+                    .increment();
+        }
+
+        @Override
+        public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata metadata) {
+            if (attemptsPerCall.get() > 0) {
+                this.metricsMeters.getAttemptCounter()
+                        .withTags((Tags.of("grpc.method", fullMethodName)))
+                        .increment();
+            }
+            if (!info.isTransparentRetry()) {
+                attemptsPerCall.incrementAndGet();
+            }
+            return new ClientTracer(this, info, fullMethodName);
+        }
+
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsMeters.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/MetricsMeters.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.client.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter.MeterProvider;
+
+/*
+ * Collection of metrics meters.
+ */
+public class MetricsMeters {
+
+    private MeterProvider<Counter> attemptCounter;
+
+    private MetricsMeters(Builder builder) {
+        this.attemptCounter = builder.attemptCounter;
+    }
+
+    public MeterProvider<Counter> getAttemptCounter() {
+        return this.attemptCounter;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    static class Builder {
+
+        private MeterProvider<Counter> attemptCounter;
+
+        private Builder() {}
+
+        public Builder setAttemptCounter(MeterProvider<Counter> counter) {
+            this.attemptCounter = counter;
+            return this;
+        }
+
+        public MetricsMeters build() {
+            return new MetricsMeters(this);
+        }
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/package-info.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metrics/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * A package containing client side classes for grpc metric collection.
+ */
+
+package net.devh.boot.grpc.client.metrics;


### PR DESCRIPTION
This PR is one of the initial efforts to support gRFC [A66: OpenTelemetry Metrics](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md) in gRPC-Spring. Even though the gRFC mentions OpenTelmetry, to keep it in sync with existing metrics, this PR as well as future ones will use Micrometer for instrumentation.

This PR adds the structure to collect gRPC metrics for [ClientInterceptor](https://grpc.github.io/grpc-java/javadoc/io/grpc/ClientInterceptor.html). To start with I have only added instrumentation for a single metric i.e `grpc.client.attempt.started`.
