### PR TITLE
Add an interceptor to support AuthenticationManagerResolver

### DIFF
--- a/docs/en/server/security.md
+++ b/docs/en/server/security.md
@@ -209,6 +209,36 @@ GrpcAuthenticationReader authenticationReader() {
 
 See also [Mutual Certificate Authentication](#mutual-certificate-authentication).
 
+#### Using AuthenticationManagerResolver
+You can also use the `AuthenticationManagerResolver` to dynamically determine the authentication
+manager to use for a particular request. This can be useful for applications that support multiple authentication
+mechanisms, such as OAuth and OpenID Connect, or that want to delegate authentication to external services.
+
+To use `AuthenticationManagerResolver`, you first need to create a bean that implements 
+the `AuthenticationManagerResolver<GrpcServerRequest>` interface instead of `AuthenticationManager`. The `resolve()` method of this bean should
+return the AuthenticationManager to use for a particular request.
+
+````java
+@Bean
+AuthenticationManagerResolver<GrpcServerRequest> grpcAuthenticationManagerResolver() {
+    return new AuthenticationManagerResolver<GrpcServerRequest>() {
+        @Override
+        public AuthenticationManager resolve(GrpcServerRequest grpcServerRequest) {
+            AuthenticationManager authenticationManager = // Check the grpc request and return an authenticationManager
+            return authenticationManager;
+        }
+    };
+}
+
+@Bean
+GrpcAuthenticationReader authenticationReader() {
+    final List<GrpcAuthenticationReader> readers = new ArrayList<>();
+    // The actual token class is dependent on your spring-security library (OAuth2/JWT/...)
+    readers.add(new BearerAuthenticationReader(accessToken -> new BearerTokenAuthenticationToken(accessToken)));
+    return new CompositeGrpcAuthenticationReader(readers);
+}
+````
+
 ### Configure Authorization
 
 This step is very important as it actually secures your application against unwanted access. You can secure your

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
@@ -19,6 +19,7 @@ package net.devh.boot.grpc.server.security.interceptors;
 import static java.util.Objects.requireNonNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -58,6 +59,7 @@ import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReade
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
+@ConditionalOnBean(AuthenticationManager.class)
 @GrpcGlobalServerInterceptor
 @Order(InterceptorOrder.ORDER_SECURITY_AUTHENTICATION)
 public class DefaultAuthenticatingServerInterceptor implements AuthenticatingServerInterceptor {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/GrpcServerRequest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/GrpcServerRequest.java
@@ -1,0 +1,53 @@
+package net.devh.boot.grpc.server.security.interceptors;
+
+import brave.grpc.GrpcRequest;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerInterceptor;
+
+/**
+ * Allows access gRPC specific aspects of a server request during sampling and parsing.
+ *
+ * @see GrpcRequest for a parsing example
+ * @since 5.12
+ */
+public class GrpcServerRequest {
+  final ServerCall<?, ?> call;
+  final Metadata headers;
+
+  public GrpcServerRequest(ServerCall<?, ?> call, Metadata headers) {
+    if (call == null) throw new NullPointerException("call == null");
+    if (headers == null) throw new NullPointerException("headers == null");
+    this.call = call;
+    this.headers = headers;
+  }
+
+  /**
+   * Returns the {@linkplain ServerCall server call} passed to {@link
+   * ServerInterceptor#interceptCall}.
+   *
+   * @since 5.12
+   */
+  public ServerCall<?, ?> call() {
+    return call;
+  }
+
+  /**
+   * Returns {@linkplain ServerCall#getMethodDescriptor()}} from the {@link #call()}.
+   *
+   * @since 5.12
+   */
+  public MethodDescriptor<?, ?> methodDescriptor() {
+    return call.getMethodDescriptor();
+  }
+
+  /**
+   * Returns the {@linkplain Metadata headers} passed to {@link ServerInterceptor#interceptCall}.
+   *
+   * @since 5.12
+   */
+  public Metadata headers() {
+    return headers;
+  }
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/ManagerResolverAuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/ManagerResolverAuthenticatingServerInterceptor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.server.security.interceptors;
+
+import io.grpc.*;
+import io.grpc.ServerCall.Listener;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A server interceptor that tries to {@link GrpcAuthenticationReader read} the credentials from the client and
+ * {@link AuthenticationManagerResolver#resolve (Context) grpcServerRequest} them. This interceptor create new {@link DefaultAuthenticatingServerInterceptor} to sets the
+ * authentication to both grpc's {@link Context} and {@link SecurityContextHolder}.
+ *
+ * <p>
+ * This works similar to the {@code org.springframework.security.web.authentication.AuthenticationFilter}.
+ * </p>
+ *
+ * <p>
+ * <b>Note:</b> This interceptor works similar to
+ * {@link Contexts#interceptCall(Context, ServerCall, Metadata, ServerCallHandler)}.
+ * </p>
+ *
+ * @author Sajad Mehrabi (mehrabisajad@gmail.com)
+ */
+@Slf4j
+@ConditionalOnBean(parameterizedContainer = AuthenticationManagerResolver.class, value = GrpcServerRequest.class)
+@GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_SECURITY_AUTHENTICATION)
+public class ManagerResolverAuthenticatingServerInterceptor implements AuthenticatingServerInterceptor {
+
+    private final AuthenticationManagerResolver<GrpcServerRequest> authenticationManagerResolver;
+    private final GrpcAuthenticationReader grpcAuthenticationReader;
+
+    /**
+     * Creates a new ManagerResolverAuthenticatingServerInterceptor with the given authentication manager resolver and reader.
+     *
+     * @param authenticationManagerResolver The authentication manager resolver used to verify the credentials.
+     * @param authenticationReader The authentication reader used to extract the credentials from the call.
+     */
+    @Autowired
+    public ManagerResolverAuthenticatingServerInterceptor(final AuthenticationManagerResolver<GrpcServerRequest> authenticationManagerResolver,
+                                                          final GrpcAuthenticationReader authenticationReader) {
+        this.authenticationManagerResolver = requireNonNull(authenticationManagerResolver, "authenticationManagerResolver");
+        this.grpcAuthenticationReader = requireNonNull(authenticationReader, "authenticationReader");
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
+            final Metadata headers, final ServerCallHandler<ReqT, RespT> next) {
+
+        GrpcServerRequest grpcServerRequest = new GrpcServerRequest(call, headers);
+        AuthenticationManager authenticationManager = this.authenticationManagerResolver.resolve(grpcServerRequest);
+
+        if (authenticationManager == null) {
+            log.debug("No authenticationManager found: Continuing unauthenticated");
+            try {
+                return next.startCall(call, headers);
+            } catch (final AccessDeniedException e) {
+                throw newNoAuthenticationManagerException(e);
+            }
+        }
+        DefaultAuthenticatingServerInterceptor authenticatingServerInterceptor = new DefaultAuthenticatingServerInterceptor(authenticationManager, this.grpcAuthenticationReader);
+        return authenticatingServerInterceptor.interceptCall(call, headers, next);
+
+    }
+
+
+    /**
+     * Wraps the given {@link AccessDeniedException} in an {@link AuthenticationException} to reflect, that no
+     * authentication was originally present in the request.
+     *
+     * @param denied The caught exception.
+     * @return The newly created {@link AuthenticationException}.
+     */
+    private static AuthenticationException newNoAuthenticationManagerException(final AccessDeniedException denied) {
+        return new BadCredentialsException("No credentials found in the request", denied);
+    }
+
+}


### PR DESCRIPTION
This proposal introduces the `AuthenticationManagerResolver<GrpcServerRequest>` to Spring's gRPC authentication framework. This provides a flexible mechanism for implementing dynamic authentication based on your specific needs.

#### The Problem:
- Traditional Spring gRPC authentication relies on fixed configuration of authentication providers, limiting flexibility.
- Changing authentication mechanisms requires code modifications and redeployments.

#### The Solution:
- Introduce AuthenticationManagerResolver<GrpcServerRequest>:
    -  Allows dynamic selection of the AuthenticationManager based on the gRPC request.
    -  Enables fine-grained control over authentication based on request headers, payload, or other criteria.