### PR TITLE
Enable gRPC Client attempt and Server metrics

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package net.devh.boot.grpc.client.autoconfigure;
 
-
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
@@ -16,19 +16,25 @@
 
 package net.devh.boot.grpc.client.autoconfigure;
 
+import java.util.function.Supplier;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+
+import com.google.common.base.Stopwatch;
 
 import io.grpc.ClientInterceptor;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
+import net.devh.boot.grpc.client.metrics.MetricsClientInterceptor;
 import net.devh.boot.grpc.common.util.InterceptorOrder;
 
 /**
@@ -40,8 +46,9 @@ import net.devh.boot.grpc.common.util.InterceptorOrder;
 @AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @AutoConfigureBefore(GrpcClientAutoConfiguration.class)
 @ConditionalOnBean(MeterRegistry.class)
-@ConditionalOnClass(MetricCollectingClientInterceptor.class)
+@ConditionalOnClass({MetricCollectingClientInterceptor.class, MetricsClientInterceptor.class})
 public class GrpcClientMetricAutoConfiguration {
+    private static final Supplier<Stopwatch> STOPWATCH_SUPPLIER = Stopwatch::createUnstarted;
 
     /**
      * Creates a {@link ClientInterceptor} that collects metrics about incoming and outgoing requests and responses.
@@ -54,6 +61,20 @@ public class GrpcClientMetricAutoConfiguration {
     @ConditionalOnMissingBean
     public MetricCollectingClientInterceptor metricCollectingClientInterceptor(final MeterRegistry registry) {
         return new MetricCollectingClientInterceptor(registry);
+    }
+
+    /**
+     * Creates a {@link ClientInterceptor} that collects metrics about client attempts and client calls.
+     *
+     * @param registry The registry used to create the metrics.
+     * @return The newly created MetricsClientInterceptor bean.
+     */
+    @ConditionalOnProperty(prefix = "grpc", name = "metricsA66Enabled", matchIfMissing = true)
+    @GrpcGlobalClientInterceptor
+    @Order(InterceptorOrder.ORDER_TRACING_METRICS)
+    @ConditionalOnMissingBean
+    public MetricsClientInterceptor metricsClientInterceptor(final MeterRegistry registry) {
+        return new MetricsClientInterceptor(registry, STOPWATCH_SUPPLIER);
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package net.devh.boot.grpc.client.autoconfigure;
 
-import java.util.function.Supplier;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -46,9 +45,8 @@ import net.devh.boot.grpc.common.util.InterceptorOrder;
 @AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @AutoConfigureBefore(GrpcClientAutoConfiguration.class)
 @ConditionalOnBean(MeterRegistry.class)
-@ConditionalOnClass({MetricCollectingClientInterceptor.class, MetricsClientInterceptor.class})
+@ConditionalOnClass(MetricCollectingClientInterceptor.class)
 public class GrpcClientMetricAutoConfiguration {
-    private static final Supplier<Stopwatch> STOPWATCH_SUPPLIER = Stopwatch::createUnstarted;
 
     /**
      * Creates a {@link ClientInterceptor} that collects metrics about incoming and outgoing requests and responses.
@@ -74,7 +72,7 @@ public class GrpcClientMetricAutoConfiguration {
     @Order(InterceptorOrder.ORDER_TRACING_METRICS)
     @ConditionalOnMissingBean
     public MetricsClientInterceptor metricsClientInterceptor(final MeterRegistry registry) {
-        return new MetricsClientInterceptor(registry, STOPWATCH_SUPPLIER);
+        return new MetricsClientInterceptor(registry, Stopwatch::createUnstarted);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.info.InfoContributor;
@@ -33,10 +34,13 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
+
+import com.google.common.base.Stopwatch;
 
 import io.grpc.BindableService;
 import io.grpc.MethodDescriptor;
@@ -47,6 +51,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.common.util.InterceptorOrder;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import net.devh.boot.grpc.server.metrics.MetricsServerStreamTracers;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 
 /**
  * Auto configuration class for Spring-Boot. This allows zero config server metrics for gRPC services.
@@ -58,8 +64,9 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 @AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @AutoConfigureBefore(GrpcServerAutoConfiguration.class)
 @ConditionalOnBean(MeterRegistry.class)
-@ConditionalOnClass(MetricCollectingServerInterceptor.class)
+@ConditionalOnClass({MetricCollectingServerInterceptor.class, MetricsServerStreamTracers.class})
 public class GrpcServerMetricAutoConfiguration {
+    private static final Supplier<Stopwatch> STOPWATCH_SUPPLIER = Stopwatch::createUnstarted;
 
     @GrpcGlobalServerInterceptor
     @Order(InterceptorOrder.ORDER_TRACING_METRICS)
@@ -73,6 +80,14 @@ public class GrpcServerMetricAutoConfiguration {
             metricCollector.preregisterService(service);
         }
         return metricCollector;
+    }
+
+    @ConditionalOnProperty(prefix = "grpc", name = "metricsA66Enabled", matchIfMissing = true)
+    @Bean
+    public GrpcServerConfigurer streamTracerFactoryConfigurer(final MeterRegistry registry) {
+        MetricsServerStreamTracers metricsServerStreamTracers = new MetricsServerStreamTracers(STOPWATCH_SUPPLIER);
+        return builder -> builder
+                .addStreamTracerFactory(metricsServerStreamTracers.getMetricsServerTracerFactory(registry));
     }
 
     @Bean

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Supplier;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.info.InfoContributor;
@@ -64,9 +63,8 @@ import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 @AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @AutoConfigureBefore(GrpcServerAutoConfiguration.class)
 @ConditionalOnBean(MeterRegistry.class)
-@ConditionalOnClass({MetricCollectingServerInterceptor.class, MetricsServerStreamTracers.class})
+@ConditionalOnClass(MetricCollectingServerInterceptor.class)
 public class GrpcServerMetricAutoConfiguration {
-    private static final Supplier<Stopwatch> STOPWATCH_SUPPLIER = Stopwatch::createUnstarted;
 
     @GrpcGlobalServerInterceptor
     @Order(InterceptorOrder.ORDER_TRACING_METRICS)
@@ -85,7 +83,8 @@ public class GrpcServerMetricAutoConfiguration {
     @ConditionalOnProperty(prefix = "grpc", name = "metricsA66Enabled", matchIfMissing = true)
     @Bean
     public GrpcServerConfigurer streamTracerFactoryConfigurer(final MeterRegistry registry) {
-        MetricsServerStreamTracers metricsServerStreamTracers = new MetricsServerStreamTracers(STOPWATCH_SUPPLIER);
+        MetricsServerStreamTracers metricsServerStreamTracers = new MetricsServerStreamTracers(
+                Stopwatch::createUnstarted);
         return builder -> builder
                 .addStreamTracerFactory(metricsServerStreamTracers.getMetricsServerTracerFactory(registry));
     }

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultClientInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultClientInterceptorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.devh.boot.grpc.test.interceptor;
+
+import static net.devh.boot.grpc.common.util.InterceptorOrder.beanFactoryAwareOrderComparator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import io.grpc.ClientInterceptor;
+import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
+import io.micrometer.core.instrument.binder.grpc.ObservationGrpcClientInterceptor;
+import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
+import net.devh.boot.grpc.client.metrics.MetricsClientInterceptor;
+
+@SpringBootTest
+@SpringJUnitConfig(classes = {GrpcClientAutoConfiguration.class})
+@EnableAutoConfiguration
+@DirtiesContext
+public class DefaultClientInterceptorTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private GlobalClientInterceptorRegistry registry;
+
+    @Test
+    void testOrderingOfTheDefaultInterceptors() {
+        final List<ClientInterceptor> expected = new ArrayList<>();
+        expected.add(this.applicationContext.getBean(MetricCollectingClientInterceptor.class));
+        expected.add(this.applicationContext.getBean(MetricsClientInterceptor.class));
+        expected.add(this.applicationContext.getBean(ObservationGrpcClientInterceptor.class));
+
+        final List<ClientInterceptor> actual = new ArrayList<>(this.registry.getClientInterceptors());
+        assertEquals(expected, actual);
+
+        Collections.shuffle(actual);
+        actual.sort(beanFactoryAwareOrderComparator(this.applicationContext, ClientInterceptor.class));
+        assertEquals(expected, actual);
+    }
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultClientInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultClientInterceptorTest.java
@@ -16,11 +16,9 @@
 
 package net.devh.boot.grpc.test.interceptor;
 
-import static net.devh.boot.grpc.common.util.InterceptorOrder.beanFactoryAwareOrderComparator;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -51,17 +49,13 @@ public class DefaultClientInterceptorTest {
     private GlobalClientInterceptorRegistry registry;
 
     @Test
-    void testOrderingOfTheDefaultInterceptors() {
+    void testDefaultInterceptors() {
         final List<ClientInterceptor> expected = new ArrayList<>();
         expected.add(this.applicationContext.getBean(MetricCollectingClientInterceptor.class));
         expected.add(this.applicationContext.getBean(MetricsClientInterceptor.class));
         expected.add(this.applicationContext.getBean(ObservationGrpcClientInterceptor.class));
 
         final List<ClientInterceptor> actual = new ArrayList<>(this.registry.getClientInterceptors());
-        assertEquals(expected, actual);
-
-        Collections.shuffle(actual);
-        actual.sort(beanFactoryAwareOrderComparator(this.applicationContext, ClientInterceptor.class));
-        assertEquals(expected, actual);
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
     }
 }


### PR DESCRIPTION
This PR enables by adding gRPC client and server metrics defined in the PRs (#1021 , #1031 and #1037) via auto-configuration.