### PR TITLE
Add support for maxInboundMetadataSize client configuration

### DIFF
--- a/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -234,7 +234,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
     }
 
     /**
-     * Configures limits such as max message sizes that should be used by the channel.
+     * Configures limits such as max message or metadata sizes that should be used by the channel.
      *
      * @param builder The channel builder to configure.
      * @param name The name of the client to configure.
@@ -244,6 +244,10 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         final DataSize maxInboundMessageSize = properties.getMaxInboundMessageSize();
         if (maxInboundMessageSize != null) {
             builder.maxInboundMessageSize((int) maxInboundMessageSize.toBytes());
+        }
+        final DataSize maxInboundMetadataSize = properties.getMaxInboundMetadataSize();
+        if (maxInboundMetadataSize != null) {
+            builder.maxInboundMetadataSize((int) maxInboundMetadataSize.toBytes());
         }
     }
 

--- a/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -338,7 +338,7 @@ public class GrpcChannelProperties {
 
     /**
      * Sets the maximum size of metadata in bytes allowed to be received.
-     * If not set ({@code null}) then it will default.The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
+     * If not set ({@code null}) then it will default to gRPC's default. The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
      * If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the enforcement.
      *
      * @return The maximum size of metadata in bytes allowed to be received or null if the default should be used.

--- a/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -337,9 +337,10 @@ public class GrpcChannelProperties {
     private DataSize maxInboundMetadataSize = null;
 
     /**
-     * Sets the maximum size of metadata in bytes allowed to be received.
-     * If not set ({@code null}) then it will default to gRPC's default. The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
-     * If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the enforcement.
+     * Sets the maximum size of metadata in bytes allowed to be received. If not set ({@code null}) then it will default
+     * to gRPC's default. The default is implementation-dependent, but is not generally less than 8 KiB and may be
+     * unlimited. If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE
+     * disables the enforcement.
      *
      * @return The maximum size of metadata in bytes allowed to be received or null if the default should be used.
      *
@@ -350,12 +351,13 @@ public class GrpcChannelProperties {
     }
 
     /**
-     * Sets the maximum size of metadata in bytes allowed to be received.
-     * If not set ({@code null}) then it will default.The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
-     * If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the enforcement.
+     * Sets the maximum size of metadata in bytes allowed to be received. If not set ({@code null}) then it will
+     * default.The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited. If
+     * set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the
+     * enforcement.
      *
-     * @param maxInboundMetadataSize The new maximum size of metadata in bytes allowed to be received. {@code -1} for max
-     *        possible. Null to use the gRPC's default.
+     * @param maxInboundMetadataSize The new maximum size of metadata in bytes allowed to be received. {@code -1} for
+     *        max possible. Null to use the gRPC's default.
      *
      * @see ManagedChannelBuilder#maxInboundMetadataSize(int) (int)
      */

--- a/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -333,6 +333,41 @@ public class GrpcChannelProperties {
         }
     }
 
+    @DataSizeUnit(DataUnit.BYTES)
+    private DataSize maxInboundMetadataSize = null;
+
+    /**
+     * Sets the maximum size of metadata in bytes allowed to be received.
+     * If not set ({@code null}) then it will default.The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
+     * If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the enforcement.
+     *
+     * @return The maximum size of metadata in bytes allowed to be received or null if the default should be used.
+     *
+     * @see ManagedChannelBuilder#maxInboundMetadataSize(int) (int)
+     */
+    public DataSize getMaxInboundMetadataSize() {
+        return maxInboundMetadataSize;
+    }
+
+    /**
+     * Sets the maximum size of metadata in bytes allowed to be received.
+     * If not set ({@code null}) then it will default.The default is implementation-dependent, but is not generally less than 8 KiB and may be unlimited.
+     * If set to {@code -1} then it will use the highest possible limit (not recommended). Integer.MAX_VALUE disables the enforcement.
+     *
+     * @param maxInboundMetadataSize The new maximum size of metadata in bytes allowed to be received. {@code -1} for max
+     *        possible. Null to use the gRPC's default.
+     *
+     * @see ManagedChannelBuilder#maxInboundMetadataSize(int) (int)
+     */
+    public void setMaxInboundMetadataSize(DataSize maxInboundMetadataSize) {
+        if (maxInboundMetadataSize == null || maxInboundMetadataSize.toBytes() >= 0) {
+            this.maxInboundMetadataSize = maxInboundMetadataSize;
+        } else if (maxInboundMetadataSize.toBytes() == -1) {
+            this.maxInboundMetadataSize = DataSize.ofBytes(Integer.MAX_VALUE);
+        } else {
+            throw new IllegalArgumentException("Unsupported maxInboundMetadataSize: " + maxInboundMetadataSize);
+        }
+    }
     // --------------------------------------------------
 
     private Boolean fullStreamDecompression;

--- a/grpc-client-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -95,6 +95,12 @@
 			"description": "The maximum message size allowed to be received by the channel.\nIf not set (null) then it will default to gRPC's default.\nIf set to -1 then it will use the highest possible limit (not recommended)."
 		},
 		{
+			"name": "grpc.client.GLOBAL.max-inbound-metadata-size",
+			"type": "org.springframework.util.unit.DataSize",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "the maximum size of metadata in bytes allowed to be received. \nIf not set (null) then it will default to gRPC's default. \nIf set to {@code -1} then it will use the highest possible limit (not recommended)."
+		},
+		{
 			"name": "grpc.client.GLOBAL.negotiation-type",
 			"type": "net.devh.boot.grpc.client.config.NegotiationType",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",

--- a/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
+++ b/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
@@ -33,7 +33,8 @@ import org.springframework.util.unit.DataSize;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "grpc.client.test.keepAliveTime=42m",
-        "grpc.client.test.maxInboundMessageSize=5MB"
+        "grpc.client.test.maxInboundMessageSize=5MB",
+        "grpc.client.test.maxInboundMetadataSize=3MB"
 })
 class GrpcChannelPropertiesGivenUnitTest {
 
@@ -45,6 +46,7 @@ class GrpcChannelPropertiesGivenUnitTest {
         final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
         assertEquals(Duration.ofMinutes(42), properties.getKeepAliveTime());
         assertEquals(DataSize.ofMegabytes(5), properties.getMaxInboundMessageSize());
+        assertEquals(DataSize.ofMegabytes(3), properties.getMaxInboundMetadataSize());
     }
 
 }

--- a/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
+++ b/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
@@ -33,7 +33,8 @@ import org.springframework.util.unit.DataSize;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "grpc.client.test.keepAliveTime=42",
-        "grpc.client.test.maxInboundMessageSize=5242880"
+        "grpc.client.test.maxInboundMessageSize=5242880",
+        "grpc.client.test.maxInboundMetadataSize=3145728"
 })
 class GrpcChannelPropertiesNoUnitTest {
 
@@ -45,6 +46,7 @@ class GrpcChannelPropertiesNoUnitTest {
         final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
         assertEquals(Duration.ofSeconds(42), properties.getKeepAliveTime());
         assertEquals(DataSize.ofMegabytes(5), properties.getMaxInboundMessageSize());
+        assertEquals(DataSize.ofMegabytes(3), properties.getMaxInboundMetadataSize());
     }
 
 }


### PR DESCRIPTION
Add support for maxInboundMetadataSize client configuration. 
If metadata (for example an exception message) exceeds the limit we may receive a client error:

```
io.grpc.StatusRuntimeException: INTERNAL: RST_STREAM closed stream. HTTP/2 error code: PROTOCOL_ERROR
```

See: https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelBuilder.html#maxInboundMetadataSize(int)
See: https://github.com/LogNet/grpc-spring-boot-starter/blob/master/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcServerProperties.java#L128