### PR TITLE
compileOnly for grpc-inprocess/implementation for grpc-netty-shaded

### DIFF
--- a/grpc-client-spring-boot-starter/build.gradle
+++ b/grpc-client-spring-boot-starter/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     //  this means it can be used implicitly without specifying the dependency (unless you wish to override with a different version, or exclude)
     optionalSupportApi 'io.grpc:grpc-netty'
     optionalSupportApi 'io.netty:netty-transport-native-epoll'
-    api 'io.grpc:grpc-inprocess'
-    api 'io.grpc:grpc-netty-shaded'
+    compileOnly 'io.grpc:grpc-inprocess'
+    implementation 'io.grpc:grpc-netty-shaded'
     api 'io.grpc:grpc-protobuf'
     api 'io.grpc:grpc-stub'
 

--- a/grpc-server-spring-boot-starter/build.gradle
+++ b/grpc-server-spring-boot-starter/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     optionalSupportImplementation "com.alibaba.cloud:spring-cloud-starter-alibaba-nacos-discovery"
     optionalSupportImplementation 'io.zipkin.brave:brave-instrumentation-grpc'
     optionalSupportApi 'io.grpc:grpc-netty'
-    api 'io.grpc:grpc-inprocess'
-    api 'io.grpc:grpc-netty-shaded'
+    compileOnly 'io.grpc:grpc-inprocess'
+    implementation 'io.grpc:grpc-netty-shaded'
     api 'io.grpc:grpc-protobuf'
     api 'io.grpc:grpc-stub'
     api 'io.grpc:grpc-services'


### PR DESCRIPTION
* The `grpc-inprocess` module exists mostly for testing purposes, we don't need it at runtime.
* The classes inside `grpc-netty-shaded` are repackaged, users are not supposed to access those internal packages, so implementation is enough