### PR TITLE
Updated the source links that provide visualizations of the Project Setup

### DIFF
--- a/docs/en/client/getting-started.md
+++ b/docs/en/client/getting-started.md
@@ -26,7 +26,7 @@ This section deals with how to get Spring to connect to a grpc server and manage
 
 Before we start adding the dependencies lets start with some of our recommendation for your project setup.
 
-![project setup](/grpc-spring-boot-starter/assets/images/client-project-setup.svg)
+![project setup](https://grpc-ecosystem.github.io/grpc-spring/assets/images/client-project-setup.svg)
 
 We recommend splitting your project into 2-3 separate modules.
 

--- a/docs/en/client/getting-started.md
+++ b/docs/en/client/getting-started.md
@@ -26,7 +26,7 @@ This section deals with how to get Spring to connect to a grpc server and manage
 
 Before we start adding the dependencies lets start with some of our recommendation for your project setup.
 
-![project setup](https://grpc-ecosystem.github.io/grpc-spring/assets/images/client-project-setup.svg)
+![project setup](/grpc-spring/assets/images/client-project-setup.svg)
 
 We recommend splitting your project into 2-3 separate modules.
 

--- a/docs/en/server/getting-started.md
+++ b/docs/en/server/getting-started.md
@@ -28,7 +28,7 @@ This section describes the steps necessary to convert your application into a gr
 
 Before we start adding the dependencies lets start with some of our recommendation for your project setup.
 
-![project setup](https://grpc-ecosystem.github.io/grpc-spring/assets/images/server-project-setup.svg)
+![project setup](/grpc-spring/assets/images/server-project-setup.svg)
 
 We recommend splitting your project into 2-3 separate modules.
 

--- a/docs/en/server/getting-started.md
+++ b/docs/en/server/getting-started.md
@@ -28,7 +28,7 @@ This section describes the steps necessary to convert your application into a gr
 
 Before we start adding the dependencies lets start with some of our recommendation for your project setup.
 
-![project setup](/grpc-spring-boot-starter/assets/images/server-project-setup.svg)
+![project setup](https://grpc-ecosystem.github.io/grpc-spring/assets/images/server-project-setup.svg)
 
 We recommend splitting your project into 2-3 separate modules.
 

--- a/docs/zh-CN/client/getting-started.md
+++ b/docs/zh-CN/client/getting-started.md
@@ -26,7 +26,7 @@
 
 在我们开始添加依赖关系之前，让我们项目的一些设置建议开始。
 
-![项目创建](https://grpc-ecosystem.github.io/grpc-spring/assets/images/client-project-setup.svg)
+![项目创建](/grpc-spring/assets/images/client-project-setup.svg)
 
 我们建议将您的项目分为2至3个不同的模块。
 

--- a/docs/zh-CN/client/getting-started.md
+++ b/docs/zh-CN/client/getting-started.md
@@ -26,7 +26,7 @@
 
 在我们开始添加依赖关系之前，让我们项目的一些设置建议开始。
 
-![项目创建](/grpc-spring-boot-starter/assets/images/client-project-setup.svg)
+![项目创建](https://grpc-ecosystem.github.io/grpc-spring/assets/images/client-project-setup.svg)
 
 我们建议将您的项目分为2至3个不同的模块。
 

--- a/docs/zh-CN/server/getting-started.md
+++ b/docs/zh-CN/server/getting-started.md
@@ -28,7 +28,7 @@
 
 在我们开始添加依赖关系之前，让我们项目的一些设置建议开始。
 
-![项目创建](/grpc-spring-boot-starter/assets/images/server-project-setup.svg)
+![项目创建](https://grpc-ecosystem.github.io/grpc-spring/assets/images/server-project-setup.svg)
 
 我们建议将您的项目分为2至3个不同的模块。
 

--- a/docs/zh-CN/server/getting-started.md
+++ b/docs/zh-CN/server/getting-started.md
@@ -28,7 +28,7 @@
 
 在我们开始添加依赖关系之前，让我们项目的一些设置建议开始。
 
-![项目创建](https://grpc-ecosystem.github.io/grpc-spring/assets/images/server-project-setup.svg)
+![项目创建](/grpc-spring/assets/images/server-project-setup.svg)
 
 我们建议将您的项目分为2至3个不同的模块。
 


### PR DESCRIPTION
Embedded valid source links for visualizing the [Project Setup](https://github.com/grpc-ecosystem/grpc-spring/blob/master/docs/en/server/getting-started.md#project-setup) for the `grpc-spring-server` and [Project Setup](https://github.com/grpc-ecosystem/grpc-spring/blob/master/docs/en/client/getting-started.md#project-setup) for the `grpc-spring-client` components.

Resolves [Issue 1077](https://github.com/grpc-ecosystem/grpc-spring/issues/1077)