### PR TITLE
Retrieve the peer certificate from the certificate array

### DIFF
--- a/grpc-server-spring-boot-starter/src/main/java/net/devh/boot/grpc/server/security/authentication/SSLContextGrpcAuthenticationReader.java
+++ b/grpc-server-spring-boot-starter/src/main/java/net/devh/boot/grpc/server/security/authentication/SSLContextGrpcAuthenticationReader.java
@@ -53,7 +53,7 @@ public class SSLContextGrpcAuthenticationReader implements GrpcAuthenticationRea
             log.trace("Peer not verified via certificate", e);
             return null;
         }
-        return fromCertificate(certs[certs.length - 1]);
+        return fromCertificate(certs[0]);
     }
 
     /**


### PR DESCRIPTION
The `SSLContextGrpcAuthenticationReader` reads the last certificate from the peer certificates array, however I believe the intent was probably to retrieve the peer certificate, not an intermediate certificate.

https://github.com/grpc-ecosystem/grpc-spring/blob/de71ce3deaa48c220bcade928268806c5e971656/grpc-server-spring-boot-starter/src/main/java/net/devh/boot/grpc/server/security/authentication/SSLContextGrpcAuthenticationReader.java#L56

[The Javadoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/SSLSession.html#getPeerCertificates()) of `javax.net.ssl.SSLSession#getPeerCertificates` specifies that it returns:

> an ordered array of peer certificates, with the peer's own certificate first followed by any certificate authorities.

If there are no intermediate CA then the array with have length 1, and there will be no difference in behavior. This is probably why this bug has not been reported before (I don't think).