### PR TITLE
Fix setting maxInboundMetadataSize from GLOBAL

### DIFF
--- a/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-starter/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -501,6 +501,9 @@ public class GrpcChannelProperties {
         if (this.maxInboundMessageSize == null) {
             this.maxInboundMessageSize = config.maxInboundMessageSize;
         }
+        if (this.maxInboundMetadataSize == null) {
+            this.maxInboundMetadataSize = config.maxInboundMetadataSize;
+        }
         if (this.negotiationType == null) {
             this.negotiationType = config.negotiationType;
         }

--- a/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGlobalTest.java
+++ b/grpc-client-spring-boot-starter/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGlobalTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Tests whether the global property fallback works.
@@ -34,6 +35,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(properties = {
         "grpc.client.GLOBAL.keepAliveTime=23m",
         "grpc.client.GLOBAL.keepAliveTimeout=31s",
+        "grpc.client.GLOBAL.maxInboundMessageSize=5MB",
+        "grpc.client.GLOBAL.maxInboundMetadataSize=3MB",
         "grpc.client.test.keepAliveTime=42m"})
 class GrpcChannelPropertiesGlobalTest {
 
@@ -52,4 +55,11 @@ class GrpcChannelPropertiesGlobalTest {
         assertEquals(Duration.ofSeconds(31), this.grpcChannelsProperties.getChannel("test").getKeepAliveTimeout());
     }
 
+    @Test
+    void testCopyDefaults() {
+        assertEquals(DataSize.ofMegabytes(5),
+                this.grpcChannelsProperties.getChannel("test").getMaxInboundMessageSize());
+        assertEquals(DataSize.ofMegabytes(3),
+                this.grpcChannelsProperties.getChannel("test").getMaxInboundMetadataSize());
+    }
 }


### PR DESCRIPTION
maxInboundMetadataSize works as expected after https://github.com/grpc-ecosystem/grpc-spring/pull/1064 if you set it for the needed channel.
But it was missed for GLOBAL in `copyDefaultsFrom` method

```
grpc:
  client:
    GLOBAL:
      max-inbound-metadata-size: 16384 # value here is not copied to other services
    service:
      address: service:6565
      max-inbound-metadata-size: 16384 # you have to specify value for service even it's already present for  GLOBAL
      ```