### PR TITLE
fix: changes grpc server exception handler order

### DIFF
--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
@@ -45,7 +45,7 @@ public final class InterceptorOrder {
     /**
      * The order value for global exception handling interceptors.
      */
-    public static final int ORDER_GLOBAL_EXCEPTION_HANDLING = 0;
+    public static final int ORDER_GLOBAL_EXCEPTION_HANDLING = 3000;
     /**
      * The order value for tracing and metrics collecting interceptors.
      */
@@ -67,6 +67,8 @@ public final class InterceptorOrder {
      * {@link Ordered#LOWEST_PRECEDENCE}. This is the default for interceptors without specified priority.
      */
     public static final int ORDER_LAST = Ordered.LOWEST_PRECEDENCE;
+
+    private InterceptorOrder() {}
 
     /**
      * Creates a new Comparator that takes {@link Order} annotations on bean factory methods into account.
@@ -100,7 +102,5 @@ public final class InterceptorOrder {
             return null;
         });
     }
-
-    private InterceptorOrder() {}
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/advice/GrpcAdviceWithMetricsTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/advice/GrpcAdviceWithMetricsTest.java
@@ -1,0 +1,112 @@
+
+package net.devh.boot.grpc.test.advice;
+
+import static io.grpc.Status.INVALID_ARGUMENT;
+import static io.micrometer.core.instrument.binder.grpc.GrpcObservationDocumentation.LowCardinalityKeyNames.STATUS_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.server.advice.GrpcAdvice;
+import net.devh.boot.grpc.server.advice.GrpcExceptionHandler;
+import net.devh.boot.grpc.server.autoconfigure.GrpcAdviceAutoConfiguration;
+import net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration;
+import net.devh.boot.grpc.server.autoconfigure.GrpcServerMicrometerTraceAutoConfiguration;
+import net.devh.boot.grpc.server.service.GrpcService;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.InProcessConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
+
+
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@SpringJUnitConfig(classes = {
+        InProcessConfiguration.class,
+        BaseAutoConfiguration.class,
+        GrpcAdviceWithMetricsTest.TestConfig.class
+})
+@ImportAutoConfiguration(classes = {GrpcAdviceAutoConfiguration.class,
+        GrpcServerMetricAutoConfiguration.class,
+        GrpcServerMicrometerTraceAutoConfiguration.class})
+@AutoConfigureObservability
+@DirtiesContext
+class GrpcAdviceWithMetricsTest {
+
+    @GrpcClient("test")
+    protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    public static Stream<Arguments> metricsFlavourProvider() {
+        return Stream.of(
+                Arguments.of("grpc.server.processing.duration", "statusCode"),
+                Arguments.of("grpc.server", STATUS_CODE.asString()));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        meterRegistry.clear();
+    }
+
+    @ParameterizedTest
+    @MethodSource("metricsFlavourProvider")
+    void shouldRegisterMetricsStatusCodeWhenUsingGrpcAdvice(String metricName, String statusCodeTagName) {
+        var exception = assertThrows(StatusRuntimeException.class, () -> {
+            blockingStub.error(Empty.getDefaultInstance());
+        });
+        assertEquals(INVALID_ARGUMENT, exception.getStatus());
+
+        var meter = Optional.ofNullable(meterRegistry.find(metricName)
+                .tags(statusCodeTagName, Status.Code.INVALID_ARGUMENT.name()).timer())
+                .orElseGet(() -> fail("expected meter with statusCode to be registered"));
+
+        assertEquals(1L, meter.count());
+    }
+
+
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @GrpcAdvice
+        public static class ExceptionHandler {
+            @GrpcExceptionHandler
+            public Status handleAnyException(Exception e) {
+                return INVALID_ARGUMENT.withCause(e);
+            }
+        }
+
+        @GrpcService
+        public static class TestGrpcAdviceService extends TestServiceGrpc.TestServiceImplBase {
+            @Override
+            public void error(Empty request, StreamObserver<Empty> responseObserver) {
+                throw new RuntimeException("a simulated error");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `GrpcExceptionInterceptor` bean after the `ObservationGrpcServerInterceptor` and the `MetricCollectingServerInterceptor` and before the `ExceptionTranslatingServerInterceptor`.
This is necessary in order to allow the later interceptor to process the error response after the exception handler is executed, more precisely to add the returned `status code` to the context/meter.

Im not entirely sure but i believe this was introduced as an unintentional consequence of the added support for [Order](https://github.com/grpc-ecosystem/grpc-spring/pull/737/files#diff-96de4406135a56a86c3443cb117b6fa3eb9b73213e3753a456d0e181f1860930) because the [GrpcAdviceAutoConfiguration](https://github.com/grpc-ecosystem/grpc-spring/blob/a18aeeb25e60114ea773a621bfdc44902513ed07/grpc-server-spring-boot-starter/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcAdviceAutoConfiguration.java#L71) already had the `@Order` with the [0 precedence](https://github.com/grpc-ecosystem/grpc-spring/blob/a18aeeb25e60114ea773a621bfdc44902513ed07/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java#L48) it was just not doing anything.

fixes #789 #1088 
